### PR TITLE
Fix parsing OPAM file with whitespace after key

### DIFF
--- a/OPAMToNPM.py
+++ b/OPAMToNPM.py
@@ -15,7 +15,7 @@ def yieldKVPair(f):
         if l.startswith("#"):
             continue
         l = l.split("#")[0]
-        g = re.search(r"^([a-zA-Z\-]+):", l)
+        g = re.search(r"^([a-zA-Z\-]+)\s*:", l)
         if not g:
             current += l
         else:


### PR DESCRIPTION
This bug caused `uutf`'s `conflicts` to be included as dependency.

https://github.com/ocaml/opam-repository/blob/2ffce85/packages/uutf/uutf.0.9.4/opam

```
depopts: ["cmdliner"
          "cmdliner" {test} ]
conflicts : ["cmdliner" { < "0.9.6" } ]
```

-> https://github.com/npm-opam/uutf/blob/fdbc8eb/package.json#L43

```
    "dependencies": {
        ...
        "@opam-alpha/cmdliner": "< 0.9.6",
        ...
    },
```
