### PR TITLE
add tyxml

### DIFF
--- a/publishedPackages.txt
+++ b/publishedPackages.txt
@@ -68,6 +68,7 @@ tls
 tsdl
 topkg
 typerep
+tyxml
 utop
 uuidm
 variantslib


### PR DESCRIPTION
It's already present https://www.npmjs.com/package/@opam-alpha/tyxml (probably as a dependency), but can't be installed because of:

```
npm ERR! Darwin 16.4.0
npm ERR! argv "/usr/local/Cellar/node6-lts/6.9.1/bin/node" "/usr/local/bin/npm" "i" "-S" "@opam-alpha/tyxml"
npm ERR! node v6.9.1
npm ERR! npm  v4.1.1
npm ERR! code ETARGET

npm ERR! notarget No compatible version found: @opam-alpha/uutf@>= 1.0.0
npm ERR! notarget Valid install targets:
npm ERR! notarget 0.9.4
npm ERR! notarget 
npm ERR! notarget This is most likely not a problem with npm itself.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.
npm ERR! notarget 
npm ERR! notarget It was specified as a dependency of 'markup-actual'
npm ERR! notarget 
```

I hope putting it explicitly in the list will resolve this issue.